### PR TITLE
Set fix versions for tensorflow to 1.25.2 a.o.

### DIFF
--- a/.github/workflows/AlgorithmTest_ST_B-U585I-IOT02A_MR.yaml
+++ b/.github/workflows/AlgorithmTest_ST_B-U585I-IOT02A_MR.yaml
@@ -42,7 +42,7 @@ jobs:
       uses: ARM-software/cmsis-actions/armlm@v1
 
     - name: Install python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
 

--- a/Alif/AppKit-E7_USB/Board/AppKit-E7_M55_HP/Board_HP.clayer.yml
+++ b/Alif/AppKit-E7_USB/Board/AppKit-E7_M55_HP/Board_HP.clayer.yml
@@ -43,7 +43,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.8.0
-    - pack: ARM::ethos-u-core-driver@^1.24.8
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List of include paths passed via the command line to the build tool.
   add-path:

--- a/Alif/AppKit-E7_USB/algorithm/ML/ML.clayer.yml
+++ b/Alif/AppKit-E7_USB/algorithm/ML/ML.clayer.yml
@@ -8,11 +8,11 @@ layer:
 
     - pack: ARM::ml-embedded-eval-kit-uc-api@^24.8.0
 
-    - pack: tensorflow::flatbuffers@^1.25.2
-    - pack: tensorflow::gemmlowp@^1.25.2
-    - pack: tensorflow::kissfft@^1.25.2
-    - pack: tensorflow::ruy@^1.25.2
-    - pack: tensorflow::tensorflow-lite-micro@^1.25.2
+    - pack: tensorflow::flatbuffers@1.25.2
+    - pack: tensorflow::gemmlowp@1.25.2
+    - pack: tensorflow::kissfft@1.25.2
+    - pack: tensorflow::ruy@1.25.2
+    - pack: tensorflow::tensorflow-lite-micro@1.25.2
 
   connections:
     - connect: Layer with CMSIS-RTOS2

--- a/Alif/AppKit-E8_USB/Board/AppKit-E8_M55_HP/Board_HP-U85.clayer.yml
+++ b/Alif/AppKit-E8_USB/Board/AppKit-E8_M55_HP/Board_HP-U85.clayer.yml
@@ -37,7 +37,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.10.0
-    - pack: ARM::ethos-u-core-driver@^1.25.2
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List miscellaneous options passed via the command line to the build tool.
   misc:

--- a/Alif/AppKit-E8_USB/Board/AppKit-E8_M55_HP/Board_HP.clayer.yml
+++ b/Alif/AppKit-E8_USB/Board/AppKit-E8_M55_HP/Board_HP.clayer.yml
@@ -45,7 +45,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.10.0
-    - pack: ARM::ethos-u-core-driver@^1.25.2
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List miscellaneous options passed via the command line to the build tool.
   misc:

--- a/Alif/AppKit-E8_USB/algorithm/ML/ML.clayer.yml
+++ b/Alif/AppKit-E8_USB/algorithm/ML/ML.clayer.yml
@@ -8,11 +8,11 @@ layer:
 
     - pack: ARM::ml-embedded-eval-kit-uc-api@^24.8.0
 
-    - pack: tensorflow::flatbuffers@^1.25.2
-    - pack: tensorflow::gemmlowp@^1.25.2
-    - pack: tensorflow::kissfft@^1.25.2
-    - pack: tensorflow::ruy@^1.25.2
-    - pack: tensorflow::tensorflow-lite-micro@^1.25.2
+    - pack: tensorflow::flatbuffers@1.25.2
+    - pack: tensorflow::gemmlowp@1.25.2
+    - pack: tensorflow::kissfft@1.25.2
+    - pack: tensorflow::ruy@1.25.2
+    - pack: tensorflow::tensorflow-lite-micro@1.25.2
 
   connections:
     - connect: Layer with CMSIS-RTOS2

--- a/Alif/DevKit-E8_ETH/Board/DevKit-E8_M55_HP/Board_HP-U85.clayer.yml
+++ b/Alif/DevKit-E8_ETH/Board/DevKit-E8_M55_HP/Board_HP-U85.clayer.yml
@@ -43,7 +43,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.10.0
-    - pack: ARM::ethos-u-core-driver@^1.25.2
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List miscellaneous options passed via the command line to the build tool.
   misc:

--- a/Alif/DevKit-E8_ETH/Board/DevKit-E8_M55_HP/Board_HP.clayer.yml
+++ b/Alif/DevKit-E8_ETH/Board/DevKit-E8_M55_HP/Board_HP.clayer.yml
@@ -51,7 +51,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.10.0
-    - pack: ARM::ethos-u-core-driver@^1.25.2
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List miscellaneous options passed via the command line to the build tool.
   misc:

--- a/Alif/DevKit-E8_ETH/algorithm/ML/ML.clayer.yml
+++ b/Alif/DevKit-E8_ETH/algorithm/ML/ML.clayer.yml
@@ -8,11 +8,11 @@ layer:
 
     - pack: ARM::ml-embedded-eval-kit-uc-api@^24.8.0
 
-    - pack: tensorflow::flatbuffers@^1.25.2
-    - pack: tensorflow::gemmlowp@^1.25.2
-    - pack: tensorflow::kissfft@^1.25.2
-    - pack: tensorflow::ruy@^1.25.2
-    - pack: tensorflow::tensorflow-lite-micro@^1.25.2
+    - pack: tensorflow::flatbuffers@1.25.2
+    - pack: tensorflow::gemmlowp@1.25.2
+    - pack: tensorflow::kissfft@1.25.2
+    - pack: tensorflow::ruy@1.25.2
+    - pack: tensorflow::tensorflow-lite-micro@1.25.2
 
   connections:
     - connect: Layer with CMSIS-RTOS2

--- a/Alif/DevKit-E8_USB/Board/DevKit-E8_M55_HP/Board_HP-U85.clayer.yml
+++ b/Alif/DevKit-E8_USB/Board/DevKit-E8_M55_HP/Board_HP-U85.clayer.yml
@@ -43,7 +43,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.10.0
-    - pack: ARM::ethos-u-core-driver@^1.25.2
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List miscellaneous options passed via the command line to the build tool.
   misc:

--- a/Alif/DevKit-E8_USB/Board/DevKit-E8_M55_HP/Board_HP.clayer.yml
+++ b/Alif/DevKit-E8_USB/Board/DevKit-E8_M55_HP/Board_HP.clayer.yml
@@ -51,7 +51,7 @@ layer:
     - pack: ARM::CMSIS@^6.2.0
     - pack: ARM::CMSIS-Compiler@^2.1.0
     - pack: ARM::CMSIS-Driver@^2.10.0
-    - pack: ARM::ethos-u-core-driver@^1.25.2
+    - pack: ARM::ethos-u-core-driver@1.25.2
 
   # List miscellaneous options passed via the command line to the build tool.
   misc:

--- a/Alif/DevKit-E8_USB/algorithm/ML/ML.clayer.yml
+++ b/Alif/DevKit-E8_USB/algorithm/ML/ML.clayer.yml
@@ -8,11 +8,11 @@ layer:
 
     - pack: ARM::ml-embedded-eval-kit-uc-api@^24.8.0
 
-    - pack: tensorflow::flatbuffers@^1.25.2
-    - pack: tensorflow::gemmlowp@^1.25.2
-    - pack: tensorflow::kissfft@^1.25.2
-    - pack: tensorflow::ruy@^1.25.2
-    - pack: tensorflow::tensorflow-lite-micro@^1.25.2
+    - pack: tensorflow::flatbuffers@1.25.2
+    - pack: tensorflow::gemmlowp@1.25.2
+    - pack: tensorflow::kissfft@1.25.2
+    - pack: tensorflow::ruy@1.25.2
+    - pack: tensorflow::tensorflow-lite-micro@1.25.2
 
   connections:
     - connect: Layer with CMSIS-RTOS2


### PR DESCRIPTION
- Set fix versions for tensorflow to 1.25.2 
- Updated actions/setup-python to version 6